### PR TITLE
Always set the conditional "X" flag on POSIX ACLs NethServer/dev#5111

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-ibays-set-permissions
+++ b/root/etc/e-smith/events/actions/nethserver-ibays-set-permissions
@@ -67,6 +67,8 @@ if($acl) {
     if($? != 0) {
         warn "[ERROR] setting shared folder ACLs \"$acl\"\n";
         $errors++;
+    } else {
+        warn "[NOTICE] set POSIX ACLs on $ibayPath: $acl\n";
     }
 }
 
@@ -106,11 +108,11 @@ sub int2acl
 {
     my $val = shift;
     if($val == 2) {
-        return 'r--';
+        return 'r-X';
     } elsif($val == 4) {
-        return '-w-';
+        return '-wX';
     } elsif($val == 6) {
-        return 'rw-';
+        return 'rwX';
     }
 
     return '---';


### PR DESCRIPTION
The "X" flag, "execute only if the file is a directory or already has
execute permission for some user". See setfacl(1) manpage.

NethServer/dev#5111
