### PR TITLE
Fix ibay default group owner

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-ibays-migrate-begin
+++ b/root/etc/e-smith/events/actions/nethserver-ibays-migrate-begin
@@ -23,11 +23,13 @@
 use strict;
 use esmith::AccountsDB;
 use esmith::event;
+use Sys::Hostname;
 
 my $event = shift;
 my $sourceDir = shift;
 my $esmithDbDir = '/home/e-smith/db';
 my $errors = 0;
+my ($systemName, $domainName) = split(/\./, Sys::Hostname::hostname(), 2);
 
 if( ! $event ) {
     die("Missing event argument!\n");
@@ -64,9 +66,14 @@ foreach my $srcIbay ($srcAccountsDb->ibays()) {
     my %access = %{defined $accessMap{$srcIbay->prop('UserAccess')} ? 
 		       $accessMap{$srcIbay->prop('UserAccess')} : $accessMap{default}};
 
+    my $defaultGroup = 'domain users@' . $domainName;
+    if( ! getgrnam($defaultGroup)) {
+        $defaultGroup = 'root';
+    }
+
     $dstIbay->merge_props(
 	Description => join(' ', $srcIbay->prop('Name'), '[migration]'),
-	OwningGroup => ($srcIbay->prop('Group') eq 'shared' ? 'locals' : $srcIbay->prop('Group')),
+	OwningGroup => ($srcIbay->prop('Group') eq 'shared' ? $defaultGroup : sprintf('%s@%s', $srcIbay->prop('Group'), $domainName)),
 	AclRead => '',
 	AclWrite => '',
 	%access);

--- a/root/etc/e-smith/events/actions/nethserver-ibays-migrate-commit
+++ b/root/etc/e-smith/events/actions/nethserver-ibays-migrate-commit
@@ -71,14 +71,16 @@ foreach my $ibay ($dstAccountsDb->get_all_by_prop('type' => 'ibay-migrate')) {
 
 }
 
-# Restore ACLs
-chdir '/var/lib/nethserver/ibay/';
-system("/bin/sed 's/^group:shared:/group:locals:/' $sourceDir/home/e-smith/db/acls.dump | /usr/bin/setfacl --restore=/dev/stdin");
-if($? != 0) {
-    warn("[ERROR] failed to restore POSIX ACLs\n");
-    $errors++;
-}
 
+if(getgrnam('domain users')) {
+    # Restore ACLs, if "domain users" group exists
+    chdir '/var/lib/nethserver/ibay/';
+    system("/bin/sed 's/^group:shared:/group:domain users:/' $sourceDir/home/e-smith/db/acls.dump | /usr/bin/setfacl --restore=/dev/stdin");
+    if($? != 0) {
+        warn("[ERROR] failed to restore POSIX ACLs\n");
+        $errors++;
+    }
+}
 
 if($errors > 0) {
     warn "[WARNING] $errors error(s) occurred in $0 action\n";


### PR DESCRIPTION
- The default group is "Domain Users", if defined
- Skip restoring ACLs if "Domain Users" is not defined

NethServer/dev#5196