### PR TITLE
Set root as owner

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-ibays-set-permissions
+++ b/root/etc/e-smith/events/actions/nethserver-ibays-set-permissions
@@ -124,19 +124,9 @@ sub calcDirectoryOwners
 {
     my @uidGid = (0, 0);
 
-    my $ownerUser = 'nobody';
-    my $owningGroup = 'nobody';
+    my $owningGroup = 'root';
     if ( ($configDb->get_prop('sssd', 'Provider') || '') eq 'ad' ) {
-        $ownerUser = 'administrator@' . $configDb->get_value('DomainName');
         $owningGroup = ($ibay->prop('OwningGroup') || 'root');
-    }
-
-    my $ownerEnt = getpwnam($ownerUser);
-    if ($ownerEnt) {
-        $uidGid[0] = $ownerEnt->uid;
-    } else {
-        $errors ++;
-        warn "[ERROR] Couldn't set \"$ownerUser\" as shared folder owner\n";
     }
 
     my $groupEnt = getgrnam($owningGroup);


### PR DESCRIPTION
- Affects only new shared folders
- Full permissions for guest access are retained, if no accounts
provider is configured
- No longer rely on `administrator`: can be disabled, can be renamed, can be deleted (?)

NethServer/dev#5392